### PR TITLE
Remove inclusion of interface

### DIFF
--- a/service/hook/class.tx_linkhandler_localRecordListGetTableHook.php
+++ b/service/hook/class.tx_linkhandler_localRecordListGetTableHook.php
@@ -22,8 +22,6 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-require_once PATH_t3lib . 'interfaces/interface.t3lib_localrecordlistgettablehook.php';
-
 /**
  * {@inheritdoc}
  *


### PR DESCRIPTION
The inclusion of the interfaces was using a removed constant.

On the other side, the inclusion of classes is not needed, thanks to the autoloader
