### PR TITLE
If typolink generates parameter.-Array the link cannot be created

### DIFF
--- a/Classes/TypolinkHandler.php
+++ b/Classes/TypolinkHandler.php
@@ -120,6 +120,11 @@ class TypolinkHandler implements SingletonInterface
             $contentObjectRenderer
     ) {
 
+        // if parameter is set as array ("parameter."), the link can not be resolved, so unset
+        if (is_array($configuration['parameter.'])) {
+            unset($configuration['parameter.']);
+        }
+
         // Extract the link parts (i.e. parameter, target, class, title and additional parameters
         $this->linkParameters = GeneralUtility::makeInstance(TypoLinkCodecService::class)->decode($linkParameters);
         // Add information from the parameter


### PR DESCRIPTION
Hi François,

I have the following scenario:
We use page´s media field (so images from sys_file_reference) to build a header slider. The Slider is built with TypoScript cObject "FILES". This one has a "renderObj = COA", where inside the COA a cObject TEXT generates the typolink.
Now, the typolink has to use "typolink.parameter.data = file:current:link", which works for normal (internal) pages. I added the line "mergeWithLinkhandlerConfiguration = 1" and linked to a news record.
Ah, "returnLast = url" is also set.
So now, in the frontend the href of the link is "Error :". So i debugged and found out, that the whole message would be "Error: no file object", as it tries to find the file in the meanwhile given news record (instead of pages).
But as "$linkHandlerValue" keeps the right string for the news link, it works if you unset the this array "$configuration['parameter.']".

So that´s the story about this pull request. Maybe you also think, that this is a good thing?

Thanks for the great linkhandler, dude.

Kind regards
merzilla
(t3quetsche)
