### PR TITLE
Bugfix: wrong conflicts

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -37,8 +37,8 @@ $EM_CONF[$_EXTKEY] = array(
                         'typo3' => '7.6.1-7.9.99',
                 ),
                 'conflicts' => array(
-                        'ch_rterecords',
-                        'tinymce_rte',
+                        'ch_rterecords' => '',
+                        'tinymce_rte' => '',
                 ),
                 'suggests' => array(),
         ),


### PR DESCRIPTION
there must be an value for the array keys. Without the extension can't be loaded. (TYPO3 7.6.5 and composermode)