### PR TITLE
[BUGFIX] Remove version number from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
       "role": "Developer"
     }
   ],
-  "version": "3.1.1",
   "require": {
     "typo3/cms-core": ">=7.6.1,<8.0"
   },


### PR DESCRIPTION
Since Composer is intelligent enough to detect the version number
from the Git tags there is no need to put it in the composer.json.

This removes the risk that the composer.json version does not
match the release version (as it is currently for 3.1.2).