### PR TITLE
[BUGFIX] Fixed wrong Iteration in Link Migration Tool

### DIFF
--- a/Classes/Command/LinkMigrationCommandController.php
+++ b/Classes/Command/LinkMigrationCommandController.php
@@ -151,7 +151,8 @@ class LinkMigrationCommandController extends CommandController
                     // The last string is optional. If it exists, it is already a 4-part record reference,
                     // i.e. a reference using the new syntax and which does not need to be migrated.
                     preg_match_all('/record:(\w+):(\w+)(:\w+)?/', $record[$field], $matches);
-                    foreach ($matches as $index => $match) {
+					$numberOfMatches = count ($matches[0]);
+                    for ($index = 0; $index < $numberOfMatches; $index++) {
                         // Consider only matches that have 3 parts (i.e. 4th part is empty)
                         // NOTE: although not captured, the first part is "record:"
                         if ($matches[3][$index] === '') {


### PR DESCRIPTION
Iteration over matches migrates only the first four entries, because it only loops over the four parts of the mtaches array.