### PR TITLE
[BUGFIX] Migration & Link validation

### DIFF
--- a/Classes/Command/LinkMigrationCommandController.php
+++ b/Classes/Command/LinkMigrationCommandController.php
@@ -151,7 +151,7 @@ class LinkMigrationCommandController extends CommandController
                     // The last string is optional. If it exists, it is already a 4-part record reference,
                     // i.e. a reference using the new syntax and which does not need to be migrated.
                     preg_match_all('/record:(\w+):(\w+)(:\w+)?/', $record[$field], $matches);
-                    foreach ($matches as $index => $match) {
+                    foreach ($matches[0] as $index => $match) {
                         // Consider only matches that have 3 parts (i.e. 4th part is empty)
                         // NOTE: although not captured, the first part is "record:"
                         if ($matches[3][$index] === '') {

--- a/Classes/Domain/Model/RecordLink.php
+++ b/Classes/Domain/Model/RecordLink.php
@@ -115,12 +115,11 @@ class RecordLink
         if (empty($recordReference)) {
             throw new \InvalidArgumentException('Record reference cannot be empty', 1457367830);
         }
-        $referenceParts = explode(':', $recordReference);
-        if (count($referenceParts) === 4) {
-            $this->recordReference = $recordReference;
-            $this->configurationKey = $referenceParts[1];
-            $this->table = $referenceParts[2];
-            $this->id = (int)$referenceParts[3];
+        if (preg_match('/^record:(\w+):(\w+):(\d+)/', $recordReference, $matches)) {
+            $this->recordReference = $matches[0];
+            $this->configurationKey = $matches[1];
+            $this->table = $matches[2];
+            $this->id = (int)$matches[3];
         } else {
             throw new \InvalidArgumentException(
                 'Expected record reference structure is "record:key:table:id"',


### PR DESCRIPTION
This solves an issue when migration the old 3-part link syntax, like addressed in pull request #44, but a bit more elegant.
Furthermore it solves non-working link validation, if the link contains a title with a colon.